### PR TITLE
fix qr files not working

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -332,7 +332,7 @@ function loadTxt2Array(lines) {
 					break;
 
 				default:
-					throw "Error invalid text QR caracters"
+					throw `Error invalid text QR caracters: ${lines[i][j]}`
 			}
 		}
     }

--- a/js/main.js
+++ b/js/main.js
@@ -298,11 +298,37 @@ function getInfoBits(){
 
 /***
 *
+* Sanitize and verify qr is square before parsing it
+*
+***/
+function sanitizeQrTxt(lines) {
+	const linesOut = [];
+
+	for(let i=0;i<lines.length;i++) {
+		if(lines[i].length !== 0) {
+			linesOut.push(lines[i]);
+		}
+		else {
+			if(i+1 === lines.length) {
+				return linesOut;
+			}
+			else {
+				throw "Unexpected empty line file."
+			}
+		}
+	}
+}
+
+/***
+*
 *	Load Waidotto QR text format 
 *		 https://github.com/waidotto/strong-qr-decoder
 ***/
-function loadTxt2Array(lines) {
+function loadTxt2Array(linesIn) {
 	console.info(lines)
+    
+    var lines = sanitizeQrTxt(linesIn);
+    
     let sz = lines.length;
 
 	var data = [];

--- a/js/main.js
+++ b/js/main.js
@@ -302,6 +302,7 @@ function getInfoBits(){
 *		 https://github.com/waidotto/strong-qr-decoder
 ***/
 function loadTxt2Array(lines) {
+	console.info(lines)
     let sz = lines.length;
 
 	var data = [];
@@ -332,7 +333,7 @@ function loadTxt2Array(lines) {
 					break;
 
 				default:
-					throw `Error invalid text QR caracters: ${lines[i][j]}`
+					throw `Error invalid text QR caracter: ${lines[i][j]}; from: ${i}x${j}`
 			}
 		}
     }

--- a/js/main.js
+++ b/js/main.js
@@ -308,15 +308,16 @@ function sanitizeQrTxt(lines) {
 		if(lines[i].length !== 0) {
 			linesOut.push(lines[i]);
 		}
-		else {
-			if(i+1 === lines.length) {
-				return linesOut;
-			}
-			else {
-				throw "Unexpected empty line file."
-			}
+		else if(i+1 !== lines.length) {
+			throw "Unexpected empty line file."
 		}
 	}
+	for(let i=0;i<linesOut.length;i++) {
+		if(linesOut[i].length !== linesOut.length) {
+			throw `QR line: ${i} width:${linesOut[i].length} does not match QR size: ${linesOut.length}`
+		}
+	}
+	return linesOut;
 }
 
 /***


### PR DESCRIPTION
tried importing qr text files on firefox and it didn't work, but this fixes that by sanitizing the inputs, and also giving more readable console errors, will get around to adding a popup with the error message eventually